### PR TITLE
Usage tag: Keep tag convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Define your structure with **descriptions**:
 
 ```go
 type myconfig struct {
-	Name      string `The name of something`
-	EnableLog bool   `Enable logging into logdb`
-	MaxProcs  int    `Maximum number of procs`
+	Name      string `usage:"The name of something"`
+	EnableLog bool   `usage:"Enable logging into logdb" json:"enable_log"`
+	MaxProcs  int    `usage:"Maximum number of procs"`
 	UsersDB   db
 	LogDB     db
 }
 
 type db struct {
-	Host string `Host where db is located`
-	User string `Database user`
-	Pass string `Database password`
+	Host string `usage:"Host where db is located"`
+	User string `usage:"Database user"`
+	Pass string `usage:"Database password"`
 }
 ```
 

--- a/traverse.go
+++ b/traverse.go
@@ -33,7 +33,7 @@ func traverse_recursive(c interface{}, f callback, p []string) {
 		field := t.Type().Field(i)
 		name := field.Name
 		value := t.Field(i)
-		usage := string(field.Tag)
+		usage := field.Tag.Get("usage")
 		ptr := value.Addr().Interface()
 		kind := value.Kind()
 


### PR DESCRIPTION
[conf.json]
```jsongg
{
    "foo_bar": "foo",
    "foo_nested": {
        "foo_bar": "fopo"
    }
}
```
[main.go]
```go
type Config struct {
    FooBar string `usage:"foo" json:"foo_bar"`
    FooNested Nested `usage:"nested" json:"foo_nested"`
}

type Nested struct {
    FooBar string `usage:"foo" json:"foo_bar"`
}

func main() {
    c := &Config{}
    goconfig.Read(c)
    log.Printf("%#v\n",c)
}
```

```
$ go run main.go -h
  -config string
    	Configuration JSON file
  -foobar string
    	foo
  -foonested.foobar string
    	foo
```

```
$ go run main.go -config conf.json 
 &main.Config{FooBar:"foo", FooNested:main.Nested{FooBar:"foo"}}
```
