### PR TITLE
Add support for time.Duration strings

### DIFF
--- a/fill_args.go
+++ b/fill_args.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 )
 
 var values = map[string]interface{}{}
@@ -31,7 +32,16 @@ func FillArgs(c interface{}, args []string) error {
 	traverse(c, func(i item) {
 		name_path := strings.ToLower(strings.Join(i.Path, "."))
 
-		if reflect.Bool == i.Kind {
+		if reflect.TypeOf(time.Duration(0)) == i.Value.Type() {
+			value := ""
+			f.StringVar(&value, name_path, i.Value.Interface().(time.Duration).String(), i.Usage)
+
+			post = append(post, postFillArgs{
+				Raw:  &value,
+				item: i,
+			})
+
+		} else if reflect.Bool == i.Kind {
 			f.BoolVar(i.Ptr.(*bool), name_path, i.Value.Interface().(bool), i.Usage)
 
 		} else if reflect.Float64 == i.Kind {
@@ -81,6 +91,20 @@ func FillArgs(c interface{}, args []string) error {
 	// Postprocess flags: unsupported flags needs to be declared as string
 	// and parsed later. Here is the place.
 	for _, p := range post {
+		// Special case for durations
+		if reflect.TypeOf(time.Duration(0)) == p.Value.Type() {
+			d, err := time.ParseDuration(*p.Raw)
+			if err != nil {
+				return fmt.Errorf(
+					"'%s' should be a time.Duration string: %s",
+					p.FieldName, err.Error(),
+				)
+			}
+			p.Value.SetInt(int64(d))
+
+			continue
+		}
+
 		err := json.Unmarshal([]byte(*p.Raw), p.Ptr)
 		if err != nil {
 			return errors.New(fmt.Sprintf(

--- a/fill_args.go
+++ b/fill_args.go
@@ -93,10 +93,10 @@ func FillArgs(c interface{}, args []string) error {
 	for _, p := range post {
 		// Special case for durations
 		if reflect.TypeOf(time.Duration(0)) == p.Value.Type() {
-			d, err := time.ParseDuration(*p.Raw)
+			d, err := unmarshalDurationString(*p.Raw)
 			if err != nil {
 				return fmt.Errorf(
-					"'%s' should be a time.Duration string: %s",
+					"'%s' should be nanoseconds or a time.Duration string: %s",
 					p.FieldName, err.Error(),
 				)
 			}

--- a/fill_args_test.go
+++ b/fill_args_test.go
@@ -18,7 +18,8 @@ func TestFillArgs(t *testing.T) {
 		MyStruct    struct {
 			MyItem string
 		}
-		MyDuration time.Duration
+		MyDurationNano   time.Duration
+		MyDurationString time.Duration
 	}{}
 
 	args := []string{
@@ -31,7 +32,8 @@ func TestFillArgs(t *testing.T) {
 		"-myuint64", "64",
 		"-myuint", "4444",
 		"-mystruct.myitem", "nested",
-		"-myduration", "15s",
+		"-mydurationnano", "15000000000",
+		"-mydurationstring", "15s",
 	}
 
 	err := FillArgs(&c, args)
@@ -73,8 +75,12 @@ func TestFillArgs(t *testing.T) {
 		t.Error("MyStruct.MyItem should be 'nested'")
 	}
 
-	if c.MyDuration.String() != "15s" {
-		t.Error("MyDuration should be 15s")
+	if c.MyDurationNano.String() != "15s" {
+		t.Error("MyDurationNano should be 15s")
+	}
+
+	if c.MyDurationString.String() != "15s" {
+		t.Error("MyDurationString should be 15s")
 	}
 
 }

--- a/fill_args_test.go
+++ b/fill_args_test.go
@@ -2,6 +2,7 @@ package goconfig
 
 import (
 	"testing"
+	"time"
 )
 
 func TestFillArgs(t *testing.T) {
@@ -17,6 +18,7 @@ func TestFillArgs(t *testing.T) {
 		MyStruct    struct {
 			MyItem string
 		}
+		MyDuration time.Duration
 	}{}
 
 	args := []string{
@@ -29,6 +31,7 @@ func TestFillArgs(t *testing.T) {
 		"-myuint64", "64",
 		"-myuint", "4444",
 		"-mystruct.myitem", "nested",
+		"-myduration", "15s",
 	}
 
 	err := FillArgs(&c, args)
@@ -68,6 +71,10 @@ func TestFillArgs(t *testing.T) {
 
 	if c.MyStruct.MyItem != "nested" {
 		t.Error("MyStruct.MyItem should be 'nested'")
+	}
+
+	if c.MyDuration.String() != "15s" {
+		t.Error("MyDuration should be 15s")
 	}
 
 }

--- a/fill_environments.go
+++ b/fill_environments.go
@@ -22,7 +22,7 @@ func FillEnvironments(c interface{}) (err error) {
 		}
 
 		if reflect.TypeOf(time.Duration(0)) == i.Value.Type() {
-			if d, err := time.ParseDuration(value); err == nil {
+			if d, err := unmarshalDurationString(value); err == nil {
 				v := int64(d)
 				set(i.Ptr, &v)
 			}

--- a/fill_environments.go
+++ b/fill_environments.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func FillEnvironments(c interface{}) (err error) {
@@ -20,7 +21,13 @@ func FillEnvironments(c interface{}) (err error) {
 			return
 		}
 
-		if reflect.Bool == i.Kind {
+		if reflect.TypeOf(time.Duration(0)) == i.Value.Type() {
+			if d, err := time.ParseDuration(value); err == nil {
+				v := int64(d)
+				set(i.Ptr, &v)
+			}
+
+		} else if reflect.Bool == i.Kind {
 			if v, err := strconv.ParseBool(value); nil == err {
 				set(i.Ptr, &v)
 			}

--- a/fill_environments_test.go
+++ b/fill_environments_test.go
@@ -23,7 +23,8 @@ func TestFillEnvironments(t *testing.T) {
 		MyStruct    struct {
 			MyItem string
 		}
-		MyDuration time.Duration
+		MyDurationNano   time.Duration
+		MyDurationString time.Duration
 	}{}
 
 	os.Setenv("MYBOOLTRUE", "true")
@@ -39,7 +40,8 @@ func TestFillEnvironments(t *testing.T) {
 	os.Setenv("MYUINT", "4444")
 	os.Setenv("MYSTRUCT_MYITEM", "nested")
 	os.Setenv("MYEMPTY", "")
-	os.Setenv("MYDURATION", "15s")
+	os.Setenv("MYDURATIONNANO", "15000000000")
+	os.Setenv("MYDURATIONSTRING", "15s")
 
 	err := FillEnvironments(&c)
 	AssertNil(t, err)
@@ -96,8 +98,12 @@ func TestFillEnvironments(t *testing.T) {
 		t.Error("MyStruct.MyItem should be 'nested'")
 	}
 
-	if c.MyDuration.String() != "15s" {
-		t.Error("MyDuration should be '15s'")
+	if c.MyDurationNano.String() != "15s" {
+		t.Error("MyDurationNano should be '15s'")
+	}
+
+	if c.MyDurationString.String() != "15s" {
+		t.Error("MyDurationString should be '15s'")
 	}
 
 }

--- a/fill_environments_test.go
+++ b/fill_environments_test.go
@@ -3,6 +3,7 @@ package goconfig
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestFillEnvironments(t *testing.T) {
@@ -22,6 +23,7 @@ func TestFillEnvironments(t *testing.T) {
 		MyStruct    struct {
 			MyItem string
 		}
+		MyDuration time.Duration
 	}{}
 
 	os.Setenv("MYBOOLTRUE", "true")
@@ -37,6 +39,7 @@ func TestFillEnvironments(t *testing.T) {
 	os.Setenv("MYUINT", "4444")
 	os.Setenv("MYSTRUCT_MYITEM", "nested")
 	os.Setenv("MYEMPTY", "")
+	os.Setenv("MYDURATION", "15s")
 
 	err := FillEnvironments(&c)
 	AssertNil(t, err)
@@ -91,6 +94,10 @@ func TestFillEnvironments(t *testing.T) {
 
 	if c.MyStruct.MyItem != "nested" {
 		t.Error("MyStruct.MyItem should be 'nested'")
+	}
+
+	if c.MyDuration.String() != "15s" {
+		t.Error("MyDuration should be '15s'")
 	}
 
 }

--- a/fill_json.go
+++ b/fill_json.go
@@ -3,7 +3,11 @@ package goconfig
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"reflect"
+	"strings"
+	"time"
 )
 
 func FillJson(c interface{}, filename string) error {
@@ -17,9 +21,63 @@ func FillJson(c interface{}, filename string) error {
 		return err
 	}
 
-	err = json.Unmarshal(data, &c)
-	if nil != err {
-		return errors.New("Bad json file: " + err.Error())
+	return unmarshalJSON(data, c)
+}
+
+func unmarshalJSON(data []byte, c interface{}) error {
+	if reflect.TypeOf(c).Implements(reflect.TypeOf(new(json.Unmarshaler)).Elem()) {
+		if err := json.Unmarshal(data, c); err != nil {
+			return errors.New("Bad json file: " + err.Error())
+		}
+
+	} else {
+		var values map[string]json.RawMessage
+		if err := json.Unmarshal(data, &values); err != nil {
+			return errors.New("Bad json file: " + err.Error())
+		}
+		for k, v := range values {
+			k = strings.ToLower(k)
+			values[k] = v
+		}
+
+		traverse_json(c, func(i item) {
+			tag, ok := i.Tags.Lookup("json")
+			if ok {
+				if i := strings.Index(tag, ","); i != -1 {
+					tag = tag[:i]
+				}
+			}
+
+			var value json.RawMessage
+			if v, ok := values[tag]; ok {
+				value = v
+			} else if v, ok := values[i.FieldName]; ok {
+				value = v
+			} else if v, ok := values[strings.ToLower(i.FieldName)]; ok {
+				value = v
+			} else {
+				return
+			}
+
+			if reflect.TypeOf(i.Value.Type()).Implements(reflect.TypeOf(new(json.Unmarshaler)).Elem()) {
+				unmarshalJSON(value, i.Ptr)
+
+			} else if reflect.TypeOf(time.Duration(0)) == i.Value.Type() {
+				tmp := ""
+				if err := json.Unmarshal(value, &tmp); err != nil {
+					fmt.Println(err)
+					return
+				}
+
+				if d, err := time.ParseDuration(tmp); err == nil {
+					v := int64(d)
+					set(i.Ptr, &v)
+				}
+
+			} else {
+				json.Unmarshal(value, i.Ptr)
+			}
+		})
 	}
 
 	return nil

--- a/fill_json.go
+++ b/fill_json.go
@@ -41,8 +41,8 @@ func unmarshalJSON(data []byte, c interface{}) error {
 		}
 
 		traverse_json(c, func(i item) {
-			tag, ok := i.Tags.Lookup("json")
-			if ok {
+			tag := i.Tags.Get("json")
+			if len(tag) > 0 {
 				if i := strings.Index(tag, ","); i != -1 {
 					tag = tag[:i]
 				}

--- a/fill_json_test.go
+++ b/fill_json_test.go
@@ -24,7 +24,9 @@ const test_fill_json = `{
 	"MyStruct": {
 		"MyItem": "nested"
 	},
-	"MyDuration": "15s",
+	"MyDuration": 15000000000,
+	"MyDurationString": "15s",
+	"MyDurationNanoString": "15000000000",
 	"my_tag": "tag",
 	"myalternatecase": "lower",
 	"MyArray": [
@@ -60,11 +62,13 @@ func TestFillJson(t *testing.T) {
 		MyStruct    struct {
 			MyItem string
 		}
-		MyDuration      time.Duration
-		MyTag           string `json:"my_tag"`
-		MyAlternateCase string
-		MyArray         []int
-		MyUnmarshaler   testJsonUnmarshaler
+		MyDuration           time.Duration
+		MyDurationString     time.Duration
+		MyDurationNanoString time.Duration
+		MyTag                string `json:"my_tag"`
+		MyAlternateCase      string
+		MyArray              []int
+		MyUnmarshaler        testJsonUnmarshaler
 	}{}
 
 	err = FillJson(&c, f.Name())
@@ -108,6 +112,14 @@ func TestFillJson(t *testing.T) {
 
 	if c.MyDuration.String() != "15s" {
 		t.Error("MyDuration should be 15s")
+	}
+
+	if c.MyDurationString.String() != "15s" {
+		t.Error("MyDurationString should be 15s")
+	}
+
+	if c.MyDurationNanoString.String() != "15s" {
+		t.Error("MyDurationNanoString should be 15s")
 	}
 
 	if c.MyTag != "tag" {

--- a/fill_json_test.go
+++ b/fill_json_test.go
@@ -1,10 +1,48 @@
 package goconfig
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"reflect"
 	"testing"
+	"time"
 )
 
+const test_fill_json = `{
+	"MyBoolTrue": true,
+	"MyBoolFalse": false,
+	"MyString": "HelloWorld",
+	"MyFloat64": 1.23,
+	"MyFloat32": 1.23,
+	"MyInt64": 123,
+	"MyInt32": 123,
+	"MyInt": 8888,
+	"MyUint64": 64,
+	"MyUint32": 32,
+	"MyUint": 4444,
+	"MyEmpty": "",
+	"MyStruct": {
+		"MyItem": "nested"
+	},
+	"MyDuration": "15s",
+	"my_tag": "tag",
+	"myalternatecase": "lower",
+	"MyArray": [
+		1,
+		2
+	],
+	"MyUnmarshaler": "unmarshal"
+}`
+
 func TestFillJson(t *testing.T) {
+	f, err := ioutil.TempFile("", "test-fill-json-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err = f.WriteString(test_fill_json); err != nil {
+		t.Fatal(err)
+	}
 
 	c := struct {
 		MyBoolTrue  bool
@@ -22,10 +60,71 @@ func TestFillJson(t *testing.T) {
 		MyStruct    struct {
 			MyItem string
 		}
+		MyDuration      time.Duration
+		MyTag           string `json:"my_tag"`
+		MyAlternateCase string
+		MyArray         []int
+		MyUnmarshaler   testJsonUnmarshaler
 	}{}
 
-	FillJson(c, "")
+	err = FillJson(&c, f.Name())
+	AssertNil(t, err)
 
+	if c.MyBoolTrue != true {
+		t.Error("MyBoolTrue should be true")
+	}
+
+	if c.MyBoolFalse != false {
+		t.Error("MyBoolFalse should be false")
+	}
+
+	if c.MyString != "HelloWorld" {
+		t.Error("MyString should be 'HelloWorld'")
+	}
+
+	if c.MyFloat64 != 1.23 {
+		t.Error("MyFloat64 should be 1.23")
+	}
+
+	if c.MyInt64 != 123 {
+		t.Error("MyInt64 should be 123")
+	}
+
+	if c.MyInt != 8888 {
+		t.Error("MyInt should be 8888")
+	}
+
+	if c.MyUint64 != 64 {
+		t.Error("MyUint64 should be 64")
+	}
+
+	if c.MyUint != 4444 {
+		t.Error("MyUint should be 4444")
+	}
+
+	if c.MyStruct.MyItem != "nested" {
+		t.Error("MyStruct.MyItem should be 'nested'")
+	}
+
+	if c.MyDuration.String() != "15s" {
+		t.Error("MyDuration should be 15s")
+	}
+
+	if c.MyTag != "tag" {
+		t.Error("MyTag should be 'tag'")
+	}
+
+	if c.MyAlternateCase != "lower" {
+		t.Error("MyAlternateCase should be 'lower'")
+	}
+
+	if !reflect.DeepEqual(c.MyArray, []int{1, 2}) {
+		t.Error("MyArray should be '[1 2]'")
+	}
+
+	if c.MyUnmarshaler != "unmarshal" {
+		t.Error("MyUnmarshaler should be 'unmarshal'")
+	}
 }
 
 func TestFillJson_UnexistingFilename(t *testing.T) {
@@ -35,4 +134,15 @@ func TestFillJson_UnexistingFilename(t *testing.T) {
 	err := FillJson(&c, "/")
 	AssertNotNil(t, err)
 
+}
+
+type testJsonUnmarshaler string
+
+func (c *testJsonUnmarshaler) UnmarshalJSON(data []byte) error {
+	tmp := ""
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*c = testJsonUnmarshaler(tmp)
+	return nil
 }

--- a/traverse.go
+++ b/traverse.go
@@ -14,6 +14,7 @@ type item struct {
 	Kind      reflect.Kind
 	Path      []string
 	Value     reflect.Value
+	Tags      reflect.StructTag
 }
 
 func traverse(c interface{}, f callback) {
@@ -80,4 +81,33 @@ func traverse_recursive(c interface{}, f callback, p []string) {
 
 func traverse_array(c interface{}, f callback, p []string) {
 
+}
+
+func traverse_json(c interface{}, f callback) {
+
+	t := reflect.ValueOf(c)
+
+	// Follow pointers
+	for reflect.Ptr == t.Kind() {
+		t = t.Elem()
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Type().Field(i)
+		name := field.Name
+		value := t.Field(i)
+		usage := field.Tag.Get("usage")
+		ptr := value.Addr().Interface()
+		kind := value.Kind()
+		tags := field.Tag
+
+		f(item{
+			FieldName: name,
+			Usage:     usage,
+			Ptr:       ptr,
+			Kind:      kind,
+			Value:     value,
+			Tags:      tags,
+		})
+	}
 }

--- a/util.go
+++ b/util.go
@@ -1,6 +1,11 @@
 package goconfig
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+)
 
 func set(dest, value interface{}) {
 	dest_v := reflect.ValueOf(dest)
@@ -8,4 +13,18 @@ func set(dest, value interface{}) {
 	value_v := reflect.ValueOf(value)
 
 	dest_v.Elem().Set(value_v.Convert(dest_t).Elem())
+}
+
+func unmarshalDurationString(s string) (time.Duration, error) {
+	// nanoseconds stored as a string
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Duration(i), nil
+	}
+
+	// duration string
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
+	}
+
+	return 0, fmt.Errorf("invalid time.Duration format, use a duration string (like '15s') or nanoseconds")
 }


### PR DESCRIPTION
Added support for time.Duration strings from all 3 config sources. For args, env, and json, there are special cases for when the `i.Value.Type()` is `date.Duration`. Support for JSON files took a bit of work to recursively unmarshal the json in order to handle the special case.

This should add the support for time fields requested in #12