### PR TITLE
feat: support multiple config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 `goconfig` is a lightweight Go library that fills structs from:
 
-1. JSON config file
+1. JSON config file(s)
 2. Environment variables
 3. Command-line flags
 
@@ -133,11 +133,32 @@ Highest priority wins:
 
 1. Command-line flags
 2. Environment variables
-3. JSON config file
+3. JSON config file(s)
 4. Struct default values
 
 If `-config` is not provided and `./config.json` exists in the current working
 directory, `goconfig` loads it automatically before env vars and flags.
+
+## Multiple Config Files
+
+`-config` accepts multiple JSON file paths separated by commas. Files are loaded
+from left to right over the same struct, so later files override values from
+previous files while omitted fields keep their existing values.
+
+```bash
+myapp -config ./config.base.json,./config.prod.json,./config.local.json
+```
+
+The same comma-separated format also works with `WithConfigFile`:
+
+```go
+err := goconfig.Load(&cfg,
+	goconfig.WithConfigFile("./config.base.json,./config.prod.json"),
+)
+```
+
+Environment variables and command-line flags are still applied after all JSON
+files, so they keep higher precedence.
 
 ## Naming Convention
 
@@ -166,7 +187,7 @@ type Config struct {
 ## Built-in Flags
 
 - `-help`: displays generated help with usage and env names
-- `-config`: JSON file path to load before env and flags
+- `-config`: JSON file path or comma-separated paths to load before env and flags
 
 When `-config` is not set, `goconfig` auto-loads `config.json` if it exists.
 

--- a/fill_json.go
+++ b/fill_json.go
@@ -25,12 +25,23 @@ func FillJson(c interface{}, filename string) error {
 		}
 	}
 
-	data, err := os.ReadFile(filename)
-	if nil != err {
-		return err
+	for _, filename := range strings.Split(filename, ",") {
+		filename = strings.TrimSpace(filename)
+		if filename == "" {
+			continue
+		}
+
+		data, err := os.ReadFile(filename)
+		if nil != err {
+			return err
+		}
+
+		if err := unmarshalJSON(data, c); err != nil {
+			return err
+		}
 	}
 
-	return unmarshalJSON(data, c)
+	return nil
 }
 
 func unmarshalJSON(data []byte, c interface{}) error {

--- a/options_test.go
+++ b/options_test.go
@@ -40,6 +40,45 @@ func TestLoadWithOptionsPrecedence(t *testing.T) {
 	AssertEqual(t, c.Value, "arg")
 }
 
+func TestLoadMultipleConfigFiles(t *testing.T) {
+	dir, err := os.MkdirTemp("", "goconfig-multiple-config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	base := filepath.Join(dir, "base.json")
+	if err := os.WriteFile(base, []byte(`{"value":"base","keep":"base","nested":{"name":"base","port":8080}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	override := filepath.Join(dir, "override.json")
+	if err := os.WriteFile(override, []byte(`{"value":"override","nested":{"port":9090}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := struct {
+		Value  string
+		Keep   string
+		Nested struct {
+			Name string
+			Port int
+		}
+	}{}
+
+	err = Load(&c,
+		WithArgs([]string{"--config", base + "," + override}),
+		WithEnvLookup(func(string) (string, bool) { return "", false }),
+		WithoutImplicitConfigFile(),
+	)
+	AssertNil(t, err)
+
+	AssertEqual(t, c.Value, "override")
+	AssertEqual(t, c.Keep, "base")
+	AssertEqual(t, c.Nested.Name, "base")
+	AssertEqual(t, c.Nested.Port, 9090)
+}
+
 func TestLoadWithoutImplicitConfigFile(t *testing.T) {
 	dir, err := os.MkdirTemp("", "goconfig-no-implicit")
 	if err != nil {


### PR DESCRIPTION
Co-Author: GPT-5.5

## Summary

- Add support for loading multiple JSON config files through the existing `-config` flag.
- Accept comma-separated config paths, loaded from left to right so later files override previous ones.
- Keep the existing precedence order: JSON files first, then environment variables, then command-line flags.
- Add test coverage for multiple config files and update the README with usage examples.

Resolves #28 

## Checklist

- [x] I ran `go test ./...`
- [x] I added or updated tests for behavior changes
- [x] I updated documentation when needed
